### PR TITLE
Fix regex pattern

### DIFF
--- a/pytube/cipher.py
+++ b/pytube/cipher.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 class Cipher:
     def __init__(self, js: str):
         self.transform_plan: List[str] = get_transform_plan(js)
-        var_regex = re.compile(r"^\w+\W")
+        var_regex = re.compile(r"^\$*\w+\W")
         var_match = var_regex.search(self.transform_plan[0])
         if not var_match:
             raise RegexMatchError(


### PR DESCRIPTION
### Description

Fix regex pattern error.  Port fix from: https://github.com/pytube/pytube/pull/1771

Stack Trace:
```
Traceback (most recent call last):
  File "<project>/venv/lib/python3.11/site-packages/pytube/__main__.py", line 181, in fmt_streams
    extract.apply_signature(stream_manifest, self.vid_info, self.js)
  File "<project>/venv/lib/python3.11/site-packages/pytube/extract.py", line 409, in apply_signature
    cipher = Cipher(js=js)
             ^^^^^^^^^^^^^
  File "<project>/venv/lib/python3.11/site-packages/pytube/cipher.py", line 33, in __init__
    raise RegexMatchError(
pytube.exceptions.RegexMatchError: __init__: could not find match for ^\w+\W
```

